### PR TITLE
Adding support for BugMeNot's "Other" field

### DIFF
--- a/content/autofill.js
+++ b/content/autofill.js
@@ -20,20 +20,25 @@
 
   const possibleUsernameInput = [
     'input[type=text]',
-    'input[name=email]',
-    'input[name=mail]',
     'input[name=user]',
     'input[name=username]',
-    'input[id=email]',
-    'input[id=mail]',
     'input[id=user]',
-    'input[id=username]',
+    'input[id=username]'
+  ]
+  const possibleEmailInput = [
+    'input[type=email]',
+    'input[name=email]',
+    'input[name=mail]',
+    'input[id=email]',
+    'input[id=user_email]',
+    'input[id=mail]'
   ]
   const possiblePasswordInput = [
     'input[type=password]',
     'input[name=password]',
     'input[name=pass]',
     'input[id=password]',
+    'input[id=user_password]',
     'input[id=pass]',
     'input[placeholder~=Password]',
     'input[placeholder~=Passwort]',
@@ -51,7 +56,7 @@
     if (msg.command === 'fill') {
       console.debug('%c[DontBugMe] Autofilling credentials', 'color: #636363;', msg);
 
-      const { user, password, autosubmit } = msg;
+      const { user, password, other, autosubmit } = msg;
 
       // Autofill credentials
       for(const selector of possibleUsernameInput) {
@@ -59,6 +64,9 @@
       }
       for(const selector of possiblePasswordInput) {
         insertToField(selector, password);
+      }
+      for(const selector of possibleEmailInput) {
+        insertToField(selector, other);
       }
 
       // Try to autosubmit

--- a/popup/js/main.js
+++ b/popup/js/main.js
@@ -119,6 +119,13 @@ const getLogins = (domain) => {
             const kbd = el.querySelectorAll('kbd');
             const user = kbd[0].innerText;
             const pass = kbd[1].innerText;
+            const other = (typeof kbd[2] !== 'undefined' ? kbd[2].innerText : '');
+
+            // If BugMeNot provides an "Other" field, display it
+            var otherElement = "";
+            if (other.length) {
+            	var otherElement = `<br /><kbd>${other}</kbd>`;
+            }
 
             // Get success rate
             const successString = el.querySelector('.success_rate').innerText;
@@ -136,6 +143,7 @@ const getLogins = (domain) => {
                     <div class="col-10 login-container">
                         <kbd>${user}</kbd><br />
                         <kbd>${pass}</kbd>
+                        ${otherElement}
                     </div>
                 </div>
             `;
@@ -153,6 +161,7 @@ const getLogins = (domain) => {
                     command: 'fill',
                     user,
                     password: pass,
+                    other: other,
                     autosubmit: localStorage.getItem('autosubmit') == 'yes'
                 }, response => {
                     // Check if chrome threw connection error


### PR DESCRIPTION
BugMeNot often provides a third credential field, "Other", which usually contains email addresses used to sign up to the websites. 

These changes allow the "Other" field to be pulled through to the extension.

Example website to test with: https://greasyfork.org/en/users/sign_in

**Note:** some BugMeNot submitters might include email addresses in the first ("Username") field and usernames in the "Other" field, so this won't work perfectly every time. 

It would be useful to include some logic which tries to determine if the data in a field looks like an email address and if so it tries to insert it into the relevant "email" fields. 